### PR TITLE
RTM (websocket) and bot disconnect issue fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ It may be helpful to have one terminal tab open per process
 
 It is required to have multiple tabs open 
 
+0. start the local postgres server:
+  * `npm run dev:startdb`
 1. Drop current database (uncle) by starting another database:
   * `psql anotherdatabase`
   Within the database:

--- a/README.md
+++ b/README.md
@@ -35,4 +35,26 @@ It may be helpful to have one terminal tab open per process
 4. run the build process to bundle client files and transpile code
   * `npm run dev:watchClient`
 
+#### Local bot testing
+
+It is required to have multiple tabs open 
+
+1. Drop current database (uncle) by starting another database:
+  * `psql anotherdatabase`
+  Within the database:
+  * `drop database uncle`
+2. Create a new database (uncle) and start:
+  * `createdb uncle`
+  * `psql uncle`
+  * `\c uncle`
+3. run the build process to bundle files and transpile code
+  * `npm run dev:buildserver`
+4. run the (node) server from the root directory of this project
+  * `npm run dev:start`
+5. Multiple saves might be required to generate all tables in database
+  * command + s in sublime
+6. Drop the current App in slack.com/apps under manage tab. Click Remove App
+7. Add the app
+8. Run node server/dist/utils/jobScraper.js to add jobs to database
+9. Interact with the bot
 

--- a/server/src/bot.js
+++ b/server/src/bot.js
@@ -8,6 +8,9 @@ dotenv.config();
 const store = {};
 
 const connection = Botkit.slackbot({
+  //this will make it possible to be interactive with
+  //the convo.ask function
+  interactive_replies: true,
   debug: false
 });
 
@@ -29,6 +32,16 @@ const teams = () => {
     });
 }
 
+const addTeamBot = (createdTeam) => {
+  let data = createdTeam.dataValues;
+  let temp = connection.spawn({
+    token: data.slackBotToken
+  });
+
+  store[data.slackTeamId] = temp;
+  store[data.slackTeamId].startRTM();
+}
+
 //allow you to do RTM without having to create a new team
 //note this is imported to server.js first
 //then to teamModel (for hook afterCreate)
@@ -39,10 +52,73 @@ connection.hears("jobs", ['direct_message'], function(bot, message) {
   userJobsListener.replyWithJobs(bot, message);
 });
 
+// const BUCKLEY = connection.spawn({
+//   //Create .env file in the root directory and add SLACK_BOT_TOKEN
+//   token: process.env.SLACK_BOT_TOKEN
+// });
 
-export default { 
-  store, teams  
-};
+// BUCKLEY.startRTM();
+
+connection.hears("", ['direct_message'], function(bot, message) {
+  console.log('replying to message');
+  bot.ask({
+    'text': `Yoyo wat's snapping?`,
+    attachments: [
+      {
+        text: 'Do you like my buttons?',
+        fallback: 'Unable to show',
+        callback_id: '123',
+        attachment_type: 'default',
+        actions: [
+          {
+            'name': 'yes',
+            'text': 'Yes',
+            'value': 'yes',
+            'type': 'button'
+          },
+          {
+            'name': 'no',
+            'text': 'No',
+            'value': 'no',
+            'type': 'button'
+          }
+        ]
+      }, [
+        {
+          pattern: 'yes',
+          callback: (response, convo) => {
+            convo.say('FABULOUS!');
+            convo.next();
+            //do something such as send info to database
+          }
+        },  
+        {
+          pattern: 'no',
+          callback: (response, convo) => {
+            convo.say('Too bad.');
+            convo.next();
+          }
+        }
+      ]
+    ]
+  });
+});
+
+const jobs = (response, convo) => {
+  convo.ask('Jobs Jobs Jobs Jobs Jobs', (response, convo) => {
+    convo.say('Is that all...?');
+    convo.next();
+  })
+}
+
+const no = (response, convo) => {
+  convo.ask('Alright, is that your final answer?', (response, convo) => {
+    convo.say(`That's too bad. Try again.`);
+    convo.next();
+  })
+}
+
+export { store, teams, addTeamBot };
 
 
 

--- a/server/src/bot.js
+++ b/server/src/bot.js
@@ -55,6 +55,10 @@ teams();
 //Handle different bot listeners
 connection.hears("jobs", ['direct_message'], function(bot, message) {
   console.log('this is the message, ', message )
+
+  //this function continues to check if profile (name/location)
+  //has been completed, in case the original websocket was closed
+  //prior to completing onboarding
   checkProfile.checkStage(bot, message);
   userJobsListener.replyWithJobs(bot, message);
 });

--- a/server/src/bot.js
+++ b/server/src/bot.js
@@ -15,7 +15,11 @@ const connection = Botkit.slackbot({
   debug: false,
 });
 
+//allow you to do RTM without having to create a new team
+//note this is imported to server.js first
+//then to teamModel (for hook afterCreate)
 const teams = () => {
+  console.log('starting instances of bots in database')
   Team.findAll()
     .then(teams => {
       for (let i = 0; i < teams.length; i++) {
@@ -46,11 +50,6 @@ const addTeamBot = (createdTeam) => {
   store[data.slackTeamId] = temp;
   store[data.slackTeamId].startRTM();
 }
-
-//allow you to do RTM without having to create a new team
-//note this is imported to server.js first
-//then to teamModel (for hook afterCreate)
-teams();
 
 //Handle different bot listeners
 connection.hears("jobs", ['direct_message'], function(bot, message) {

--- a/server/src/bot.js
+++ b/server/src/bot.js
@@ -11,7 +11,7 @@ const connection = Botkit.slackbot({
   //this will make it possible to be interactive with
   //the convo.ask function
   // interactive_replies: true,
-  debug: false
+  debug: false,
 });
 
 const teams = () => {
@@ -20,7 +20,10 @@ const teams = () => {
       for (let i = 0; i < teams.length; i++) {
         let data = teams[i].dataValues;
         let temp = connection.spawn({
-          token: data.slackBotToken
+          token: data.slackBotToken,
+          //add a retry to count to let the bot reconnect 
+          //automatic retries are disabled by default
+          retry: 20
         });
         //dangerous! slack team tokens....
         store[data.slackTeamId] = temp;
@@ -35,7 +38,8 @@ const teams = () => {
 const addTeamBot = (createdTeam) => {
   let data = createdTeam.dataValues;
   let temp = connection.spawn({
-    token: data.slackBotToken
+    token: data.slackBotToken,
+    retry: 20
   });
 
   store[data.slackTeamId] = temp;
@@ -63,6 +67,18 @@ connection.hears("", ['direct_message'], (bot, message) => {
   console.log('replying to message');
   // bot.startConversation(message, buttonTest);
 });
+
+connection.on('rtm_open', (bot) => {
+  console.log(`** The RTM api just opened at ${Date.now()}`);
+})
+
+connection.on('rtm_close', (bot) => {
+  console.log(`** The RTM api just closed at ${Date.now()}`);
+});
+
+connection.on('rtm_reconnect_failed', (bot) => {
+  console.log(`** The RTM api retry attempts have been exhausted at ${Date.now()}`);
+})
 
 /////////////////////////////////////////////////////////
 //This section is for interactive buttons

--- a/server/src/bot.js
+++ b/server/src/bot.js
@@ -10,7 +10,7 @@ const store = {};
 const connection = Botkit.slackbot({
   //this will make it possible to be interactive with
   //the convo.ask function
-  interactive_replies: true,
+  // interactive_replies: true,
   debug: false
 });
 
@@ -59,64 +59,75 @@ connection.hears("jobs", ['direct_message'], function(bot, message) {
 
 // BUCKLEY.startRTM();
 
-connection.hears("", ['direct_message'], function(bot, message) {
+connection.hears("", ['direct_message'], (bot, message) => {
   console.log('replying to message');
-  bot.ask({
-    'text': `Yoyo wat's snapping?`,
-    attachments: [
-      {
-        text: 'Do you like my buttons?',
-        fallback: 'Unable to show',
-        callback_id: '123',
-        attachment_type: 'default',
-        actions: [
-          {
-            'name': 'yes',
-            'text': 'Yes',
-            'value': 'yes',
-            'type': 'button'
-          },
-          {
-            'name': 'no',
-            'text': 'No',
-            'value': 'no',
-            'type': 'button'
-          }
-        ]
-      }, [
-        {
-          pattern: 'yes',
-          callback: (response, convo) => {
-            convo.say('FABULOUS!');
-            convo.next();
-            //do something such as send info to database
-          }
-        },  
-        {
-          pattern: 'no',
-          callback: (response, convo) => {
-            convo.say('Too bad.');
-            convo.next();
-          }
-        }
-      ]
-    ]
-  });
+  // bot.startConversation(message, buttonTest);
 });
 
-const jobs = (response, convo) => {
-  convo.ask('Jobs Jobs Jobs Jobs Jobs', (response, convo) => {
-    convo.say('Is that all...?');
-    convo.next();
-  })
-}
+/////////////////////////////////////////////////////////
+//This section is for interactive buttons
+// const buttonTest = (err, convo) => {
+//   convo.ask({
+//     attachments: [
+//       {
+//         title: 'Do you like my buttons?',
+//         callback_id: '123',
+//         attachment_type: 'default',
+//         actions: [
+//           {
+//             "name": "yes",
+//             "text": "Yes",
+//             "value": "y",
+//             "type": "button",
+//           },
+//           {
+//             "name": "no",
+//             "text": "No",
+//             "value": "n",
+//             "type": "button",
+//           }
+//         ]
+//       }, [
+//         {
+//           pattern: "y",
+//           callback: (reply, convo) => {
+//             convo.say('FABULOUS!');
+//             convo.next();
+//             //do something such as send info to database
+//           }
+//         },  
+//         {
+//           pattern: "n",
+//           callback: (reply, convo) => {
+//             convo.say('Too bad.');
+//             convo.next();
+//           }
+//         },
+//         {
+//           default: true,
+//           callback: (reply, convo) => {
+//             return;
+//           }
+//         }
+//       ]
+//     ]
+//   });
+// };
 
-const no = (response, convo) => {
-  convo.ask('Alright, is that your final answer?', (response, convo) => {
-    convo.say(`That's too bad. Try again.`);
-    convo.next();
-  })
-}
+// const jobs = (response, convo) => {
+//   convo.ask('Jobs Jobs Jobs Jobs Jobs', (response, convo) => {
+//     convo.say('Is that all...?');
+//     convo.next();
+//   })
+// }
+
+// const no = (response, convo) => {
+//   convo.ask('Alright, is that your final answer?', (response, convo) => {
+//     convo.say(`That's too bad. Try again.`);
+//     convo.next();
+//   })
+// }
+/////////////////////////////////////////////////////////
 
 export { store, teams, addTeamBot };
 

--- a/server/src/bot.js
+++ b/server/src/bot.js
@@ -1,7 +1,8 @@
 import Botkit from 'botkit';
 import dotenv from 'dotenv';
 import Team from './teams/teamModel';
-import userJobsListener from './bots/job.js'
+import userJobsListener from './bots/job.js';
+import checkProfile from './bots/helper.js';
 
 dotenv.config();
 
@@ -53,6 +54,8 @@ teams();
 
 //Handle different bot listeners
 connection.hears("jobs", ['direct_message'], function(bot, message) {
+  console.log('this is the message, ', message )
+  checkProfile.checkStage(bot, message);
   userJobsListener.replyWithJobs(bot, message);
 });
 
@@ -74,6 +77,11 @@ connection.on('rtm_open', (bot) => {
 
 connection.on('rtm_close', (bot) => {
   console.log(`** The RTM api just closed at ${Date.now()}`);
+  bot.startRTM((err, bot, payload) => {
+    if (err) {
+      throw new Error('Could not connect to Slack');
+    }
+  });
 });
 
 connection.on('rtm_reconnect_failed', (bot) => {

--- a/server/src/bot.js
+++ b/server/src/bot.js
@@ -2,7 +2,7 @@ import Botkit from 'botkit';
 import dotenv from 'dotenv';
 import Team from './teams/teamModel';
 import userJobsListener from './bots/job';
-import checkProfile from './bots/helper';
+import helper from './bots/helper';
 
 dotenv.config();
 
@@ -58,7 +58,7 @@ connection.hears("jobs", ['direct_message'], function(bot, message) {
   //this function continues to check if profile (name/location)
   //has been completed, in case the original websocket was closed
   //prior to completing onboarding
-  checkProfile.checkStage(bot, message);
+  helper.checkStage(bot, message);
   userJobsListener.replyWithJobs(bot, message);
 });
 
@@ -80,11 +80,12 @@ connection.on('rtm_open', (bot) => {
 
 connection.on('rtm_close', (bot) => {
   console.log(`** The RTM api just closed at ${Date.now()}`);
-  bot.startRTM((err, bot, payload) => {
-    if (err) {
-      throw new Error('Could not connect to Slack');
-    }
-  });
+  //Need to determine if the retry or the bot.startRTM is reconnecting
+  // bot.startRTM((err, bot, payload) => {
+  //   if (err) {
+  //     throw new Error('Could not connect to Slack');
+  //   }
+  // });
 });
 
 connection.on('rtm_reconnect_failed', (bot) => {

--- a/server/src/bot.js
+++ b/server/src/bot.js
@@ -1,8 +1,8 @@
 import Botkit from 'botkit';
 import dotenv from 'dotenv';
 import Team from './teams/teamModel';
-import userJobsListener from './bots/job.js';
-import checkProfile from './bots/helper.js';
+import userJobsListener from './bots/job';
+import checkProfile from './bots/helper';
 
 dotenv.config();
 

--- a/server/src/bots/helper.js
+++ b/server/src/bots/helper.js
@@ -54,7 +54,7 @@ const completedReply = (bot, message) => {
 
 const inProcessReply = (bot, message) => {
   bot.startPrivateConversation({ user: message.user }, (err, convo) => {
-    convo.say(`I have found a list of jobs for you! However, ` +
+    convo.ask(`I have found a list of jobs for you! However, ` +
       `it seems like I do not have you location yet ಠ_ಠ \n` +
       `Can you tell me where you are from?`, (response, convo) => {
       convo.say(`I heard that ${response.text} is a great place. ` + 

--- a/server/src/bots/helper.js
+++ b/server/src/bots/helper.js
@@ -1,0 +1,91 @@
+import { connection } from '../bot.js';
+import User from '../users/userModel';
+import Team from '../teams/teamModel';
+import Profile from '../profile/profileModel';
+import { updateProfile } from '../bots/introduction';
+
+//we want to check if the user on the team has been
+//onboard with introduction or not, in this case
+//we can check if the profile column is at 
+//stage: null -> no name or location update
+//stage: in-process -> name update but no location
+//stage: completed -> name and location updated
+
+const checkProfile =  {
+  checkStage: (bot, message) => {
+    User.find({
+      where: { slackUserId: message.user }
+    })
+    .then(user => {
+      // console.log('this is the user inside of helper.js, ', user);
+      let userId = user.dataValues.id;
+      Profile.find({
+        where: { userId }
+      })
+      .then(profile => {
+        console.log(profile.dataValues);
+        let stage = profile.dataValues.stage;
+        //depending on the stage, would have to give different respones
+        routeOnStage(stage, bot, message);
+      })
+      .catch(err => {
+        console.log('Error with checking profile');
+      })
+    })
+    .catch(err => {
+      console.log('Error with checking users');
+    })
+  },
+};
+
+const routeOnStage = (currStage, bot, message) => {
+  if (currStage === 'completed') {
+    completedReply(bot, message);
+  } else if (currStage === 'in-process') {
+    inProcessReply(bot, message);
+  } else if (currStage === null) {
+    incompleteReply(bot, message);
+  }
+}
+
+const completedReply = (bot, message) => {
+  bot.reply(message, `Below are some jobs you might be interested in!`)
+};
+
+const inProcessReply = (bot, message) => {
+  bot.startPrivateConversation({ user: message.user }, (err, convo) => {
+    convo.say(`I have found a list of jobs for you! However, ` +
+      `it seems like I do not have you location yet ಠ_ಠ \n`
+      `Can you tell me where you are from?`, (response, convo) => {
+      convo.say(`I heard that ${response.text} is a great place. ` + 
+        `Well, I'll be here to help you out if you need me!`);
+      updateProfile(response, {stage: 'completed'})
+      convo.next();
+    });
+  });
+};
+
+const incompleteReply = (bot, message) => {
+  bot.startPrivateConversation({ user: message.user }, (err, convo) => {
+    convo.ask(`Hey there! I have found a list of jobs for you! ` + 
+      `However, it seems like I don't have your name or location ヽ(￣д￣;)ノ \n` +
+      `What's your name?`, (response, convo) => {
+      convo.say(`Nice to meet you ${response.text} !`);
+      updateProfile(response, {stage: 'in-process'})
+      followUp(response, convo);
+      convo.next();
+    });
+  });
+}
+
+const followUp = (response, convo) => {
+  convo.ask(`Can you tell me where you are from?`, (response, convo) => {
+    convo.say(`I heard that ${response.text} is a great place. ` + 
+      `Well, I'll be here to help you out if you need me!`);
+    updateProfile(response, {stage: 'completed'})
+    convo.next();
+  });
+}
+
+
+export default checkProfile;

--- a/server/src/bots/helper.js
+++ b/server/src/bots/helper.js
@@ -55,7 +55,7 @@ const completedReply = (bot, message) => {
 const inProcessReply = (bot, message) => {
   bot.startPrivateConversation({ user: message.user }, (err, convo) => {
     convo.say(`I have found a list of jobs for you! However, ` +
-      `it seems like I do not have you location yet ಠ_ಠ \n`
+      `it seems like I do not have you location yet ಠ_ಠ \n` +
       `Can you tell me where you are from?`, (response, convo) => {
       convo.say(`I heard that ${response.text} is a great place. ` + 
         `Well, I'll be here to help you out if you need me!`);

--- a/server/src/bots/introduction.js
+++ b/server/src/bots/introduction.js
@@ -18,7 +18,7 @@ const intro = (createdProfile) => {
 
     // console.log('this is buckley, ', BUCKLEY)
 
-    BUCKLEY.startPrivateConversation({user: id}, (err, convo) => {
+    BUCKLEY.startPrivateConversation({ user: id }, (err, convo) => {
       convo.ask('Yoooo, watsup?!?', (response, convo) => {
         askName(response, convo);
         convo.next();
@@ -36,7 +36,7 @@ const askName = (response, convo) => {
   convo.ask("Sweet! Nice to meet you. My Name is Buckley, What's yours?", (response, convo) => {
     console.log('This is the response: ', response);
     convo.say("Nice to meet you " + response.text + "!");
-    updateProfile(response, {name: response.text});
+    updateProfile(response, {name: response.text, stage: 'in-process'});
     askLocation(response, convo);
     convo.next();
   });
@@ -46,7 +46,7 @@ const askLocation = (response, convo) => {
   convo.ask("Where are you from?", (response, convo) => {
     convo.say(`I heard that ${response.text} is a great place. ` +
       `Well I'll be here to help you out if you need me!`);
-    updateProfile(response, {location: response.text})
+    updateProfile(response, {location: response.text, stage: 'completed'})
     convo.next();
   });
 }
@@ -71,4 +71,4 @@ const updateProfile = (response, profilePayload) => {
   });
 }
 
-export default intro;
+export { intro, updateProfile };

--- a/server/src/bots/introduction.js
+++ b/server/src/bots/introduction.js
@@ -1,6 +1,7 @@
 import User from '../users/userModel';
 import Profile from '../profile/profileModel';
 import { store } from '../bot';
+import helper from '../bots/helper'
 
 //Init convo by accepting an argument of created Profile
 const intro = (createdProfile) => {
@@ -36,7 +37,7 @@ const askName = (response, convo) => {
   convo.ask("Sweet! Nice to meet you. My Name is Buckley, What's yours?", (response, convo) => {
     console.log('This is the response: ', response);
     convo.say("Nice to meet you " + response.text + "!");
-    updateProfile(response, {name: response.text, stage: 'in-process'});
+    helper.updateProfile(response, {name: response.text, stage: 'in-process'});
     askLocation(response, convo);
     convo.next();
   });
@@ -46,7 +47,7 @@ const askLocation = (response, convo) => {
   convo.ask("Where are you from?", (response, convo) => {
     convo.say(`I heard that ${response.text} is a great place. ` +
       `Well I'll be here to help you out if you need me!`);
-    updateProfile(response, {location: response.text, stage: 'completed'})
+    helper.updateProfile(response, {location: response.text, stage: 'completed'})
     convo.next();
   });
 }
@@ -55,20 +56,4 @@ const askLocation = (response, convo) => {
 //there will be an abnormal socket close event, and it will attempt
 //too reconnect three times
 
-const updateProfile = (response, profilePayload) => {
-  User.find({
-    where: {slackUserId: response.user}
-  })
-  .then(user => {
-    Profile.find({
-      where: {userId: user.id}
-    })
-    .then(profile => {
-      profile.updateAttributes(profilePayload)
-        .then(() => console.log('Profile has been updated!'))
-        .catch(() => console.log('Could not update profile.'));
-    });
-  });
-}
-
-export { intro, updateProfile };
+export default intro;

--- a/server/src/bots/introduction.js
+++ b/server/src/bots/introduction.js
@@ -16,7 +16,7 @@ const intro = (createdProfile) => {
     // console.log('this is the user, ', user)
     const BUCKLEY = store[user.dataValues.slackTeamId];
 
-    console.log('this is buckley, ', BUCKLEY)
+    // console.log('this is buckley, ', BUCKLEY)
 
     BUCKLEY.startPrivateConversation({user: id}, (err, convo) => {
       convo.ask('Yoooo, watsup?!?', (response, convo) => {

--- a/server/src/profile/profileController.js
+++ b/server/src/profile/profileController.js
@@ -24,7 +24,6 @@ const addProfile = (req, res) => {
     created ? res.send('Profile created') : res.send('Profile already exists');
   })
   .catch(err => res.send(err));
-
 };
 
 

--- a/server/src/profile/profileModel.js
+++ b/server/src/profile/profileModel.js
@@ -1,12 +1,13 @@
 import db from '../db/db-config';
 import Sequelize from 'sequelize';
 import User from '../users/userModel';
-import introduction from '../bot/introduction';
+import { intro } from '../bots/introduction';
 
 //Generates Profile model
 let Profile = db.define('profile', {
   name: Sequelize.STRING, 
-  location: Sequelize.STRING
+  location: Sequelize.STRING,
+  stage: Sequelize.STRING
 });
 
 //Add userId to the profile as a foreign key
@@ -15,7 +16,7 @@ Profile.belongsTo(User);
 //Create a hook that will be call after a profile has been created
 Profile.hook('afterCreate', (profile, options) => {
 //   //invoke the buckley conversation bot
-  introduction(profile);
+  intro(profile);
 });
 
 Profile.sync()

--- a/server/src/profile/profileModel.js
+++ b/server/src/profile/profileModel.js
@@ -1,7 +1,7 @@
 import db from '../db/db-config';
 import Sequelize from 'sequelize';
 import User from '../users/userModel';
-import { intro } from '../bots/introduction';
+import intro from '../bots/introduction';
 
 //Generates Profile model
 let Profile = db.define('profile', {

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import bodyParser from 'body-parser';
-import bot from './bot';
+import { teams } from './bot';
 import Sequelize from 'sequelize';
 import routes from './routes/router';
 
@@ -17,5 +17,8 @@ app.use(express.static('client'));
 const router = routes(app, express);
 
 app.listen(port, () => {
+  //invoking teams to generate all instances of bots
+  //which exist in the database
+  teams();
   console.log('Server started on port ' + port);
 });

--- a/server/src/teams/teamController.js
+++ b/server/src/teams/teamController.js
@@ -71,8 +71,8 @@ const findTeamUsers = (team) => {
         }
 
         rp(usersData)
-        .then(body => console.log(body))
-        .catch(err => console.log(err));
+        .then(response => { console.log('Success: ', response.statusCode) })
+        .catch(err => { console.log('this is usersData error: ', err) });
 
       } else {
         //TODO: redirect to error page

--- a/server/src/teams/teamModel.js
+++ b/server/src/teams/teamModel.js
@@ -1,6 +1,6 @@
 import db from '../db/db-config';
 import Sequelize from 'sequelize';
-import { teams } from '../bot';
+import { addTeamBot } from '../bot'
 
 //Generates Team model
 let Team = db.define('team', {
@@ -15,7 +15,10 @@ Team.hook('afterCreate', (team, options) => {
   //invoke the method from bot.js for looping through teams
   //this will allow the bot.js store to have {teamid: instance of bot}
   //of the newly created team
-  teams();
+
+  //should call the method where we are only adding one team
+  // console.log(team);
+  addTeamBot(team);
 });
 
 Team.sync()

--- a/server/src/users/userController.js
+++ b/server/src/users/userController.js
@@ -39,7 +39,7 @@ const authUser = (req, res) => {
 
         //TODO: Fix nested promise structure -- this is an antipattern (PM)
         //Check for any team with the slack team id -- if this exists, find or create user
-        Team.findOne({ where: {slackTeamId: teamId} })
+        Team.findOne({ where: { slackTeamId: teamId} })
         .then((team) => {
           if (team !== null) {
             console.log('team exists:', team);

--- a/server/src/users/userController.js
+++ b/server/src/users/userController.js
@@ -126,16 +126,12 @@ const addUser = (req, res) => {
             created ? console.log('profile created') : console.log('profile already exists'); 
           })
           .catch(err => console.log(err));
-
       } else {
         console.log(user.name + ' exists');
       }
-
     })
     .catch(err => console.log(err));   
-
   });
-
 }
 
 const deleteUser = (req, res) => {


### PR DESCRIPTION
1. Ensure RTM will reconnect on disconnect
2. Added function to go along with posting jobs, that will ask user for name/location if profile information not populated
3. Refactored generation of key: value pair (teamId: bot instances). Now bot instances for all teams in team table will be looped through on server start, and additional teams that use the Slack button will be added to the team/bot object, instead of restarting all instances of the bots 
